### PR TITLE
Use self-hosted runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,3 +7,6 @@ jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    with:
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"


### PR DESCRIPTION

### Overview

Use `edge` self-hosted runner for tests.

### Rationale

- Reduce load on GitHub-provided runner on the organisation.
- Test out the edge revision of github-runner charm on this repo.


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
