### PR TITLE
Add domain endpoints

### DIFF
--- a/httprequest_lego_provider/serializers.py
+++ b/httprequest_lego_provider/serializers.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Serializers."""
+
+from rest_framework import serializers
+
+from .models import Domain, DomainUserPermission
+
+
+class DomainSerializer(serializers.ModelSerializer):
+    """Serializer for the Domain objects."""
+
+    class Meta:
+        """Serializer configuration.
+
+        Attributes:
+            model: the model to serialize.
+            fields: fields to serialize.
+        """
+
+        model = Domain
+        fields = "__all__"
+
+
+class DomainUserPermissionSerializer(serializers.ModelSerializer):
+    """Serializer for the DomainUserPermission objects."""
+
+    class Meta:
+        """Serializer configuration.
+
+        Attributes:
+            model: the model to serialize.
+            fields: fields to serialize.
+        """
+
+        model = DomainUserPermission
+        fields = "__all__"

--- a/httprequest_lego_provider/tests/conftest.py
+++ b/httprequest_lego_provider/tests/conftest.py
@@ -38,6 +38,32 @@ def user_auth_token(username: str, user_password: str, user: User) -> str:
 
 
 @pytest.fixture(scope="module")
+def admin_username() -> str:
+    """Provide an admin username."""
+    return "admin"
+
+
+@pytest.fixture(scope="module")
+def admin_user_password() -> str:
+    """Provide an admin user password."""
+    return secrets.token_hex()
+
+
+@pytest.fixture(scope="function")
+def admin_user(admin_username: str, admin_user_password: str) -> User:
+    """Provide an admin user."""
+    return User.objects.create_user(username, password=user_password, is_staff=True)
+
+
+@pytest.fixture(scope="function")
+def admin_user_auth_token(admin_username: str, admin_user_password: str, admin_user: User) -> str:
+    """Provide the auth_token for the admin user."""
+    return base64.b64encode(bytes(f"{admin_username}:{admin_user_password}", "utf-8")).decode(
+        "utf-8"
+    )
+
+
+@pytest.fixture(scope="module")
 def fqdn():
     """Provide a valid FQDN."""
     yield f"{FQDN_PREFIX}example.com"

--- a/httprequest_lego_provider/tests/conftest.py
+++ b/httprequest_lego_provider/tests/conftest.py
@@ -40,7 +40,7 @@ def user_auth_token(username: str, user_password: str, user: User) -> str:
 @pytest.fixture(scope="module")
 def admin_username() -> str:
     """Provide an admin username."""
-    return "admin"
+    return "test_admin_user"
 
 
 @pytest.fixture(scope="module")
@@ -52,7 +52,7 @@ def admin_user_password() -> str:
 @pytest.fixture(scope="function")
 def admin_user(admin_username: str, admin_user_password: str) -> User:
     """Provide an admin user."""
-    return User.objects.create_user(username, password=user_password, is_staff=True)
+    return User.objects.create_user(admin_username, password=admin_user_password, is_staff=True)
 
 
 @pytest.fixture(scope="function")

--- a/httprequest_lego_provider/tests/test_views.py
+++ b/httprequest_lego_provider/tests/test_views.py
@@ -54,7 +54,7 @@ def test_post_present_when_auth_header_invalid(client: Client):
 @pytest.mark.django_db
 def test_post_present_when_logged_in_and_no_fqdn(client: Client, user_auth_token: str, fqdn: str):
     """
-    arrange: log in a user.
+    arrange: log in a non-admin user.
     act: submit a POST request for the present URL.
     assert: a 403 is returned.
     """
@@ -73,7 +73,7 @@ def test_post_present_when_logged_in_and_no_permission(
     client: Client, user_auth_token: str, domain: Domain
 ):
     """
-    arrange: log in a user and insert a domain in the database.
+    arrange: log in a non-admin user and insert a domain in the database.
     act: submit a POST request for the present URL.
     assert: a 403 is returned.
     """
@@ -129,7 +129,7 @@ def test_post_present_when_logged_in_and_fqdn_invalid(client: Client, user_auth_
 @pytest.mark.django_db
 def test_get_present_when_logged_in(client: Client, user_auth_token: str):
     """
-    arrange: log in a user.
+    arrange: log in a non-admin user.
     act: submit a GET request for the present URL.
     assert: a 405 is returned.
     """
@@ -155,7 +155,7 @@ def test_post_cleanup_when_not_logged_in(client: Client):
 @pytest.mark.django_db
 def test_post_cleanup_when_logged_in_and_no_fqdn(client: Client, user_auth_token: str):
     """
-    arrange: log in a user.
+    arrange: log in a non-admin user.
     act: submit a POST request for the cleanup URL.
     assert: a 403 is returned.
     """
@@ -174,7 +174,7 @@ def test_post_cleanup_when_logged_in_and_no_permission(
     client: Client, user_auth_token: str, domain: Domain
 ):
     """
-    arrange: log in a user.
+    arrange: log in a non-admin user.
     act: submit a POST request for the cleanup URL.
     assert: a 403 is returned.
     """
@@ -230,7 +230,7 @@ def test_post_cleanup_when_logged_in_and_fqdn_invalid(client: Client, user_auth_
 @pytest.mark.django_db
 def test_get_cleanup_when_logged_in(client: Client, user_auth_token: str):
     """
-    arrange: log in a user.
+    arrange: log in a non-admin user.
     act: submit a GET request for the cleanup URL.
     assert: a 405 is returned.
     """
@@ -270,7 +270,7 @@ def test_test_jwt_token_login(
 @pytest.mark.django_db
 def test_post_domain_when_logged_in_as_non_admin_user(client: Client, user_auth_token: str):
     """
-    arrange: log in a user.
+    arrange: log in a non-admin user.
     act: submit a POST request for the domain URL.
     assert: a 403 is returned and the domain is not inserted in the database.
     """
@@ -327,7 +327,7 @@ def test_post_domain_user_permission_when_logged_in_as_non_admin_user(
     client: Client, user_auth_token: str, domain: Domain, user: User
 ):
     """
-    arrange: log in a user.
+    arrange: log in a non-admin user.
     act: submit a POST request for the domain user permission URL.
     assert: a 403 is returned and the domain is not inserted in the database.
     """

--- a/httprequest_lego_provider/tests/test_views.py
+++ b/httprequest_lego_provider/tests/test_views.py
@@ -385,7 +385,7 @@ def test_post_domain_user_permission_when_logged_in_as_admin_user(
 ):
     """
     arrange: log in an admin user.
-    act: submit a POST request for the domain user permission URL for a non existing domain.
+    act: submit a POST request for the domain user permission URL for a existing domain.
     assert: a 201 is returned and the domain user permission is inserted in the database.
     """
     response = client.post(

--- a/httprequest_lego_provider/tests/test_views.py
+++ b/httprequest_lego_provider/tests/test_views.py
@@ -308,7 +308,7 @@ def test_post_domain_when_logged_in_as_admin_user_and_domain_invalid(
 ):
     """
     arrange: log in a admin user.
-    act: submit a POST request for the domain URL.
+    act: submit a POST request with an invalid value for the domain URL.
     assert: a 400 is returned.
     """
     response = client.post(

--- a/httprequest_lego_provider/tests/test_views.py
+++ b/httprequest_lego_provider/tests/test_views.py
@@ -268,9 +268,7 @@ def test_test_jwt_token_login(
 
 
 @pytest.mark.django_db
-def test_post_domain_when_logged_in_as_non_admin_user(
-    client: Client, user_auth_token: str, fqdn: str
-):
+def test_post_domain_when_logged_in_as_non_admin_user(client: Client, user_auth_token: str):
     """
     arrange: log in a user.
     act: submit a POST request for the domain URL.
@@ -278,19 +276,17 @@ def test_post_domain_when_logged_in_as_non_admin_user(
     """
     response = client.post(
         "/api/v1/domains/",
-        data={"fqdn": fqdn},
+        data={"fqdn": "example.com"},
         headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
     )
 
     with pytest.raises(Domain.DoesNotExist):
-        Domain.objects.get(fqdn=fqdn)
+        Domain.objects.get(fqdn="example.com")
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-def test_post_domain_when_logged_in_as_admin_user(
-    client: Client, admin_user_auth_token: str, fqdn: str
-):
+def test_post_domain_when_logged_in_as_admin_user(client: Client, admin_user_auth_token: str):
     """
     arrange: log in an admin user.
     act: submit a POST request for the domain URL.
@@ -298,11 +294,11 @@ def test_post_domain_when_logged_in_as_admin_user(
     """
     response = client.post(
         "/api/v1/domains/",
-        data={"fqdn": fqdn},
+        data={"fqdn": "example.com"},
         headers={"AUTHORIZATION": f"Basic {admin_user_auth_token}"},
     )
 
-    assert Domain.objects.get(fqdn=fqdn) is not None
+    assert Domain.objects.get(fqdn="example.com") is not None
     assert response.status_code == 201
 
 

--- a/httprequest_lego_provider/urls.py
+++ b/httprequest_lego_provider/urls.py
@@ -8,8 +8,8 @@ from rest_framework.routers import DefaultRouter
 from . import views
 
 router = DefaultRouter()
-router.register(r"domains", views.DomainViewSet)
-router.register(r"domain-user-permissions", views.DomainUserPermissionViewSet)
+router.register("domains", views.DomainViewSet)
+router.register("domain-user-permissions", views.DomainUserPermissionViewSet)
 
 urlpatterns = [
     path("api/v1/cleanup/", views.handle_cleanup, name="cleanup"),

--- a/httprequest_lego_provider/urls.py
+++ b/httprequest_lego_provider/urls.py
@@ -3,11 +3,17 @@
 """Urls."""
 
 from django.urls import include, path
+from rest_framework.routers import DefaultRouter
 
 from . import views
+
+router = DefaultRouter()
+router.register(r"domains", views.DomainViewSet)
+router.register(r"domain-user-permissions", views.DomainUserPermissionViewSet)
 
 urlpatterns = [
     path("api/v1/cleanup/", views.handle_cleanup, name="cleanup"),
     path("api/v1/present/", views.handle_present, name="present"),
     path("api/v1/accounts/", include("django.contrib.auth.urls")),
+    path("api/v1/", include(router.urls)),
 ]

--- a/httprequest_lego_provider/views.py
+++ b/httprequest_lego_provider/views.py
@@ -2,15 +2,20 @@
 # See LICENSE file for licensing details.
 """Views."""
 
+# pylint:disable=too-many-ancestors
+
 from typing import Optional
 
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
+from rest_framework import viewsets
 from rest_framework.decorators import api_view
+from rest_framework.permissions import IsAdminUser
 
 from .dns import remove_dns_record, write_dns_record
 from .forms import CleanupForm, PresentForm
 from .models import Domain, DomainUserPermission
+from .serializers import DomainSerializer, DomainUserPermissionSerializer
 
 
 @api_view(["POST"])
@@ -66,3 +71,31 @@ def handle_cleanup(request: HttpRequest) -> Optional[HttpResponse]:
     except Domain.DoesNotExist:
         pass
     raise PermissionDenied
+
+
+class DomainViewSet(viewsets.ModelViewSet):
+    """Views for the Domain.
+
+    Attributes:
+        queryset: query for the objects in the model.
+        serializer_class: class used for seriqlization.
+        permission_classes: list of classes to match permissions.
+    """
+
+    queryset = Domain.objects.all()
+    serializer_class = DomainSerializer
+    permission_classes = [IsAdminUser]
+
+
+class DomainUserPermissionViewSet(viewsets.ModelViewSet):
+    """Views for the DomainUserPermission.
+
+    Attributes:
+        queryset: query for the objects in the model.
+        serializer_class: class used for seriqlization.
+        permission_classes: list of classes to match permissions.
+    """
+
+    queryset = DomainUserPermission.objects.all()
+    serializer_class = DomainUserPermissionSerializer
+    permission_classes = [IsAdminUser]

--- a/httprequest_lego_provider/views.py
+++ b/httprequest_lego_provider/views.py
@@ -78,7 +78,7 @@ class DomainViewSet(viewsets.ModelViewSet):
 
     Attributes:
         queryset: query for the objects in the model.
-        serializer_class: class used for seriqlization.
+        serializer_class: class used for serialization.
         permission_classes: list of classes to match permissions.
     """
 
@@ -92,7 +92,7 @@ class DomainUserPermissionViewSet(viewsets.ModelViewSet):
 
     Attributes:
         queryset: query for the objects in the model.
-        serializer_class: class used for seriqlization.
+        serializer_class: class used for serialization.
         permission_classes: list of classes to match permissions.
     """
 

--- a/httprequest_lego_provider/views.py
+++ b/httprequest_lego_provider/views.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 """Views."""
 
+# Disable too-many-ancestors rule since we can't control inheritance for the ViewSets.
 # pylint:disable=too-many-ancestors
 
 from typing import Optional


### PR DESCRIPTION
Applicable spec: <link> https://docs.google.com/document/d/1J8LXOn8iQHC93OulsZB-PyL6c7iSjS_FPKZbZutPck0

### Overview

<!-- A high level overview of the change -->
Add `domains/` and `domain-user-permissions/` endpoints

### Rationale

<!-- The reason the change is needed -->
The endpoints are needed to facilitate managing both the endpoints and the user endpoints matching programmatically from 3rd party systems

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
httprequest_lego_provider/urls.py
httprequest_lego_provider/serializers.py
httprequest_lego_provider/views.py


### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
