### PR TITLE
Strip version from present and cleanup endpoints

### DIFF
--- a/httprequest_lego_provider/tests/test_views.py
+++ b/httprequest_lego_provider/tests/test_views.py
@@ -133,9 +133,7 @@ def test_get_present_when_logged_in(client: Client, user_auth_token: str):
     act: submit a GET request for the present URL.
     assert: a 405 is returned.
     """
-    response = client.get(
-        "/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"}
-    )
+    response = client.get("/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"})
 
     assert response.status_code == 405
 
@@ -234,9 +232,7 @@ def test_get_cleanup_when_logged_in(client: Client, user_auth_token: str):
     act: submit a GET request for the cleanup URL.
     assert: a 405 is returned.
     """
-    response = client.get(
-        "/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"}
-    )
+    response = client.get("/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"})
 
     assert response.status_code == 405
 

--- a/httprequest_lego_provider/tests/test_views.py
+++ b/httprequest_lego_provider/tests/test_views.py
@@ -21,7 +21,7 @@ def test_post_present_when_not_logged_in(client: Client):
     act: submit a POST request for the present URL.
     assert: a 401 is returned.
     """
-    response = client.post("/api/v1/present/")
+    response = client.post("/present/")
 
     assert response.status_code == 401
 
@@ -33,7 +33,7 @@ def test_post_present_when_auth_header_empty(client: Client):
     act: submit a POST request for the present URL with an empty authorization header.
     assert: a 401 is returned.
     """
-    response = client.post("/api/v1/present/", headers={"AUTHORIZATION": ""})
+    response = client.post("/present/", headers={"AUTHORIZATION": ""})
 
     assert response.status_code == 401
 
@@ -46,7 +46,7 @@ def test_post_present_when_auth_header_invalid(client: Client):
     assert: a 401 is returned.
     """
     auth_token = base64.b64encode(bytes("invalid:invalid", "utf-8")).decode("utf-8")
-    response = client.post("/api/v1/present/", headers={"AUTHORIZATION": f"Basic {auth_token}"})
+    response = client.post("/present/", headers={"AUTHORIZATION": f"Basic {auth_token}"})
 
     assert response.status_code == 401
 
@@ -60,7 +60,7 @@ def test_post_present_when_logged_in_and_no_fqdn(client: Client, user_auth_token
     """
     value = secrets.token_hex()
     response = client.post(
-        "/api/v1/present/",
+        "/present/",
         data={"fqdn": fqdn, "value": value},
         headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
     )
@@ -79,7 +79,7 @@ def test_post_present_when_logged_in_and_no_permission(
     """
     value = secrets.token_hex()
     response = client.post(
-        "/api/v1/present/",
+        "/present/",
         data={"fqdn": domain.fqdn, "value": value},
         headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
     )
@@ -99,7 +99,7 @@ def test_post_present_when_logged_in_and_permission(
     with patch("httprequest_lego_provider.views.write_dns_record") as mocked_dns_write:
         value = secrets.token_hex()
         response = client.post(
-            "/api/v1/present/",
+            "/present/",
             data={"fqdn": domain_user_permission.domain.fqdn, "value": value},
             headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
         )
@@ -118,7 +118,7 @@ def test_post_present_when_logged_in_and_fqdn_invalid(client: Client, user_auth_
     with patch("httprequest_lego_provider.views.write_dns_record"):
         value = secrets.token_hex()
         response = client.post(
-            "/api/v1/present/",
+            "/present/",
             data={"fqdn": "example.com", "value": value},
             headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
         )
@@ -134,7 +134,7 @@ def test_get_present_when_logged_in(client: Client, user_auth_token: str):
     assert: a 405 is returned.
     """
     response = client.get(
-        "/api/v1/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"}
+        "/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"}
     )
 
     assert response.status_code == 405
@@ -147,7 +147,7 @@ def test_post_cleanup_when_not_logged_in(client: Client):
     act: submit a POST request for the cleanup URL.
     assert: a 401 is returned.
     """
-    response = client.post("/api/v1/cleanup/")
+    response = client.post("/cleanup/")
 
     assert response.status_code == 401
 
@@ -161,7 +161,7 @@ def test_post_cleanup_when_logged_in_and_no_fqdn(client: Client, user_auth_token
     """
     value = secrets.token_hex()
     response = client.post(
-        "/api/v1/cleanup/",
+        "/cleanup/",
         data={"fqdn": f"{FQDN_PREFIX}example.com", "value": value},
         headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
     )
@@ -180,7 +180,7 @@ def test_post_cleanup_when_logged_in_and_no_permission(
     """
     value = secrets.token_hex()
     response = client.post(
-        "/api/v1/cleanup/",
+        "/cleanup/",
         data={"fqdn": domain.fqdn, "value": value},
         headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
     )
@@ -200,7 +200,7 @@ def test_post_cleanup_when_logged_in_and_permission(
     with patch("httprequest_lego_provider.views.remove_dns_record") as mocked_dns_remove:
         value = secrets.token_hex()
         response = client.post(
-            "/api/v1/cleanup/",
+            "/cleanup/",
             data={"fqdn": domain_user_permission.domain.fqdn, "value": value},
             headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
         )
@@ -219,7 +219,7 @@ def test_post_cleanup_when_logged_in_and_fqdn_invalid(client: Client, user_auth_
     with patch("httprequest_lego_provider.views.remove_dns_record"):
         value = secrets.token_hex()
         response = client.post(
-            "/api/v1/cleanup/",
+            "/cleanup/",
             data={"fqdn": "example.com", "value": value},
             headers={"AUTHORIZATION": f"Basic {user_auth_token}"},
         )
@@ -235,7 +235,7 @@ def test_get_cleanup_when_logged_in(client: Client, user_auth_token: str):
     assert: a 405 is returned.
     """
     response = client.get(
-        "/api/v1/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"}
+        "/present/", headers={"AUTHORIZATION": f"Basic {user_auth_token}"}
     )
 
     assert response.status_code == 405
@@ -259,7 +259,7 @@ def test_test_jwt_token_login(
     with patch("httprequest_lego_provider.views.write_dns_record"):
         value = secrets.token_hex()
         response = client.post(
-            "/api/v1/present/",
+            "/present/",
             data={"fqdn": domain_user_permission.domain.fqdn, "value": value},
             headers={"AUTHORIZATION": f"Bearer {token}"},
         )

--- a/httprequest_lego_provider/urls.py
+++ b/httprequest_lego_provider/urls.py
@@ -12,8 +12,8 @@ router.register("domains", views.DomainViewSet)
 router.register("domain-user-permissions", views.DomainUserPermissionViewSet)
 
 urlpatterns = [
-    path("api/v1/cleanup/", views.handle_cleanup, name="cleanup"),
-    path("api/v1/present/", views.handle_present, name="present"),
+    path("cleanup/", views.handle_cleanup, name="cleanup"),
+    path("present/", views.handle_present, name="present"),
     path("api/v1/accounts/", include("django.contrib.auth.urls")),
     path("api/v1/", include(router.urls)),
 ]


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Strip version from present and cleanup endpoints

### Rationale

<!-- The reason the change is needed -->
These endpoints are standard and should be accessible in `/present` and `/cleanup` respectively

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
urls.py

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
