### PR TITLE
Fix allowed hosts config

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import json
 import os
 import urllib
 from pathlib import Path
@@ -27,7 +28,7 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", False)
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = json.loads(os.environ.get("DJANGO_ALLOWED_HOSTS", "[]"))
 
 
 # Application definition


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fix allowed hosts config by reading the DJANGO_ALLOWED_HOSTS env var

### Rationale

<!-- The reason the change is needed -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
settings.py

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
