### PR TITLE
Remove trailing dot from the fqdn when present

### DIFF
--- a/httprequest_lego_provider/forms.py
+++ b/httprequest_lego_provider/forms.py
@@ -46,7 +46,7 @@ def is_fqdn_compliant(fqdn: str) -> bool:
 class FQDNField(CharField):
     """FQDN field class."""
 
-    def validate(self, value):
+    def validate(self, value) -> None:
         """Check if value consists only of a valid FQDNs prefixed by '_acme-challenge.'.
 
         Args:
@@ -61,6 +61,17 @@ class FQDNField(CharField):
             raise ValidationError(
                 message="Please provide a valid FQDN", code="invalid", params={"value": value}
             )
+
+    def to_python(self, value) -> str:
+        """Remove the trailing dot from the FQDN if present.
+
+        Args:
+            value: field value.
+
+        Returns:
+            the FQDN without a trailing dot.
+        """
+        return value.rstrip(".")
 
 
 class PresentForm(Form):


### PR DESCRIPTION
Applicable spec: <link> https://go-acme.github.io/lego/dns/httpreq/

### Overview

<!-- A high level overview of the change -->
Remove trailing dot from the fqdn when present, per the spec above 

### Rationale

<!-- The reason the change is needed -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
forms.py

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
