### PR TITLE
Update loki library to new revision

### DIFF
--- a/charm/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/charm/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -480,7 +480,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 27
 
 logger = logging.getLogger(__name__)
 
@@ -2116,15 +2116,14 @@ class LogProxyConsumer(ConsumerBase):
                - "binsha": sha256 sum of unpacked promtail binary
         """
         # Check for Juju proxy variables and fall back to standard ones if not set
-        proxies: Optional[Dict[str, str]] = {}
-        if proxies and os.environ.get("JUJU_CHARM_HTTP_PROXY"):
-            proxies.update({"http": os.environ["JUJU_CHARM_HTTP_PROXY"]})
-        if proxies and os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
-            proxies.update({"https": os.environ["JUJU_CHARM_HTTPS_PROXY"]})
-        if proxies and os.environ.get("JUJU_CHARM_NO_PROXY"):
-            proxies.update({"no_proxy": os.environ["JUJU_CHARM_NO_PROXY"]})
-        else:
-            proxies = None
+        # If no Juju proxy variable was set, we set proxies to None to let the ProxyHandler get
+        # the proxy env variables from the environment
+        proxies = {
+            "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+            "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+        }
+        proxies = {k: v for k, v in proxies.items() if v != ""} or None
 
         proxy_handler = request.ProxyHandler(proxies)
         opener = request.build_opener(proxy_handler)


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Update the `loki_push_api` library with a new version, that fixes proxy support when downloading the promtail binary.

### Rationale

To fix proxy support when downloading the promtail binary.

### Module Changes

N/A
### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
