### PR TITLE
Bump the version of loki library in the charm

### DIFF
--- a/charm/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/charm/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -480,7 +480,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 27
+LIBPATCH = 28
 
 logger = logging.getLogger(__name__)
 
@@ -2119,9 +2119,13 @@ class LogProxyConsumer(ConsumerBase):
         # If no Juju proxy variable was set, we set proxies to None to let the ProxyHandler get
         # the proxy env variables from the environment
         proxies = {
-            "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
-            "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
-            "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+            # The ProxyHandler uses only the protocol names as keys
+            # https://docs.python.org/3/library/urllib.request.html#urllib.request.ProxyHandler
+            "https": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+            "http": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            # The ProxyHandler uses `no` for the no_proxy key
+            # https://github.com/python/cpython/blob/3.12/Lib/urllib/request.py#L2553
+            "no": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
         }
         proxies = {k: v for k, v in proxies.items() if v != ""} or None
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Increment the loki library version.

### Rationale

Implement the correct variables in the `proxies` dictionary so proxy will be used when downloading promtail.

### Module Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
