### PR TITLE
Add missing User API (url, view, serializer, tests)

### DIFF
--- a/httprequest_lego_provider/serializers.py
+++ b/httprequest_lego_provider/serializers.py
@@ -2,6 +2,9 @@
 # See LICENSE file for licensing details.
 """Serializers."""
 
+# imported-auth-user has to be disabled as the import is needed for UserSerializer
+# pylint:disable=imported-auth-user
+from django.contrib.auth.models import User
 from rest_framework import serializers
 
 from .models import Domain, DomainUserPermission
@@ -35,3 +38,18 @@ class DomainUserPermissionSerializer(serializers.ModelSerializer):
 
         model = DomainUserPermission
         fields = "__all__"
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """Serializer for the User objects."""
+
+    class Meta:
+        """Serializer configuration.
+
+        Attributes:
+            model: the model to serialize.
+            fields: fields to serialize.
+        """
+
+        model = User
+        fields = ["url", "username", "email", "groups"]

--- a/httprequest_lego_provider/urls.py
+++ b/httprequest_lego_provider/urls.py
@@ -10,6 +10,7 @@ from . import views
 router = DefaultRouter()
 router.register("domains", views.DomainViewSet)
 router.register("domain-user-permissions", views.DomainUserPermissionViewSet)
+router.register("users", views.UserViewSet)
 
 urlpatterns = [
     path("cleanup", views.handle_cleanup, name="cleanup"),

--- a/httprequest_lego_provider/views.py
+++ b/httprequest_lego_provider/views.py
@@ -7,6 +7,9 @@
 
 from typing import Optional
 
+# imported-auth-user has to be disabled as the import is needed for UserViewSet
+# pylint:disable=imported-auth-user
+from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse
 from rest_framework import viewsets
 from rest_framework.decorators import api_view
@@ -15,7 +18,7 @@ from rest_framework.permissions import IsAdminUser
 from .dns import remove_dns_record, write_dns_record
 from .forms import CleanupForm, PresentForm
 from .models import Domain, DomainUserPermission
-from .serializers import DomainSerializer, DomainUserPermissionSerializer
+from .serializers import DomainSerializer, DomainUserPermissionSerializer, UserSerializer
 
 
 @api_view(["POST"])
@@ -100,4 +103,18 @@ class DomainUserPermissionViewSet(viewsets.ModelViewSet):
 
     queryset = DomainUserPermission.objects.all()
     serializer_class = DomainUserPermissionSerializer
+    permission_classes = [IsAdminUser]
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    """Views for the User.
+
+    Attributes:
+        queryset: query for the objects in the model.
+        serializer_class: class used for serialization.
+        permission_classes: list of classes to match permissions.
+    """
+
+    queryset = User.objects.all().order_by("-date_joined")
+    serializer_class = UserSerializer
     permission_classes = [IsAdminUser]


### PR DESCRIPTION
### Overview

Add REST API route, view, serializer for Django auth.User model.

This code is untested yet as I have no local/testing environment for this project, but what I think would be enough for the needed API to become available. Please review carefully and perform the necessary edits, or raise them so I can fix them.

### Rationale

We need to be able to list and create users through the REST API.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

This is neither urgent, trivial nor complex.