### PR TITLE
Allow setting password when creating users through the API

### DIFF
--- a/httprequest_lego_provider/serializers.py
+++ b/httprequest_lego_provider/serializers.py
@@ -2,6 +2,8 @@
 # See LICENSE file for licensing details.
 """Serializers."""
 
+from django.contrib.auth.hashers import make_password
+
 # imported-auth-user has to be disabled as the import is needed for UserSerializer
 # pylint:disable=imported-auth-user
 from django.contrib.auth.models import User
@@ -49,7 +51,23 @@ class UserSerializer(serializers.ModelSerializer):
         Attributes:
             model: the model to serialize.
             fields: fields to serialize.
+            extra_kwargs: extra per-field parameters.
         """
 
         model = User
-        fields = ["url", "username", "email", "groups"]
+        fields = ["url", "username", "email", "groups", "password"]
+        extra_kwargs = {
+            "password": {"write_only": True},
+        }
+
+    def create(self, validated_data):
+        """Override default ModelSerializer create call to hash the password.
+
+        Arguments:
+            validated_data: Serializer validated data
+
+        Returns:
+            The created User object.
+        """
+        validated_data["password"] = make_password(validated_data["password"])
+        return super().create(validated_data)


### PR DESCRIPTION
### Overview

Allow setting password when creating users through the API, while not displaying it when getting users.

### Rationale

We need to be able to fully create a user, with password.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

This is neither `urgent`, `trivial` nor `complex`