### PR TITLE
Fix the API not prefixing the FQDN_PREFIX to created domains

### DIFF
--- a/httprequest_lego_provider/serializers.py
+++ b/httprequest_lego_provider/serializers.py
@@ -7,6 +7,7 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
+from .forms import FQDN_PREFIX
 from .models import Domain, DomainUserPermission
 
 
@@ -23,6 +24,18 @@ class DomainSerializer(serializers.ModelSerializer):
 
         model = Domain
         fields = "__all__"
+
+    def create(self, validated_data):
+        """Override default ModelSerializer create call to add the FQDN prefix.
+
+        Arguments:
+            validated_data: Serializer validated data
+
+        Returns:
+            The created Domain object.
+        """
+        validated_data["fqdn"] = f"{FQDN_PREFIX}{validated_data['fqdn']}"
+        return super().create(validated_data)
 
 
 class DomainUserPermissionSerializer(serializers.ModelSerializer):

--- a/httprequest_lego_provider/tests/test_views.py
+++ b/httprequest_lego_provider/tests/test_views.py
@@ -353,7 +353,7 @@ def test_post_domain_when_logged_in_as_admin_user(client: Client, admin_user_aut
         headers={"AUTHORIZATION": f"Basic {admin_user_auth_token}"},
     )
 
-    assert Domain.objects.get(fqdn="example.com") is not None
+    assert Domain.objects.get(fqdn=f"{FQDN_PREFIX}example.com") is not None
     assert response.status_code == 201
 
 


### PR DESCRIPTION
### Overview

Prefix FQDN_PREFIX when adding new domains through the Django REST API.

### Rationale

We need the Django REST API to be consistent with what the application or juju action would do.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

This is neither `urgent`, `trivial` nor `complex`