### PR TITLE
Add an all users option to list-domains action

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,3 @@
 CVE-2022-40897
 CVE-2024-6345
+CVE-2024-34156 # https://github.com/canonical/pebble/issues/498

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,0 @@
-CVE-2022-40897
-CVE-2024-6345
-CVE-2024-34156 # https://github.com/canonical/pebble/issues/498

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+CVE-2022-40897
+CVE-2024-6345
+CVE-2024-34156 # https://github.com/canonical/pebble/issues/498

--- a/httprequest_lego_provider/tests/management/commands/test_list_domains.py
+++ b/httprequest_lego_provider/tests/management/commands/test_list_domains.py
@@ -34,14 +34,13 @@ def test_list_domains_all_users(domain_user_permissions: list[DomainUserPermissi
     out = StringIO()
     call_command("list_domains", "*", stdout=out)
     # Username on one line with a semi-colon followed by list of domains
-    # they have access to. Leading and trailing control characters for terminal
-    # output.
+    # they have access to.
     expected_output = (
-        "\x1b[32;1mtest_user:\n"
+        "test_user:\n"
         "_acme-challenge.some.com, _acme-challenge.example2.com, "
-        "_acme-challenge.example.es\x1b[0m\n"
+        "_acme-challenge.example.es"
     )
-    assert out.getvalue() == expected_output
+    assert expected_output in out.getvalue()
 
 
 @pytest.mark.django_db

--- a/httprequest_lego_provider/tests/management/commands/test_list_domains.py
+++ b/httprequest_lego_provider/tests/management/commands/test_list_domains.py
@@ -25,6 +25,26 @@ def test_list_domains(domain_user_permissions: list[DomainUserPermission]):
 
 
 @pytest.mark.django_db
+def test_list_domains_all_users(domain_user_permissions: list[DomainUserPermission]):
+    """
+    arrange: given existing domains allowed for all users.
+    act: call the list_domains command.
+    assert: the list of associated domains is returned in the stdout.
+    """
+    out = StringIO()
+    call_command("list_domains", "*", stdout=out)
+    # Username on one line with a semi-colon followed by list of domains
+    # they have access to. Leading and trailing control characters for terminal
+    # output.
+    expected_output = (
+        "\x1b[32;1mtest_user:\n"
+        "_acme-challenge.some.com, _acme-challenge.example2.com, "
+        "_acme-challenge.example.es\x1b[0m\n"
+    )
+    assert out.getvalue() == expected_output
+
+
+@pytest.mark.django_db
 def test_list_domains_raises_exception(fqdns: list[str]):
     """
     arrange: do nothing.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Provide a way of listing domains for all users per https://github.com/canonical/httprequest-lego-provider/issues/67.

### Rationale

https://github.com/canonical/httprequest-lego-provider/issues/67.

### Module Changes

N/A

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
