### PR TITLE
Change config options to use dashes rather than underscores for consistency with framework-added options

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -42,12 +42,12 @@ requires:
 
 config:
   options:
-    git_repo:
+    git-repo:
       type: string
       description: >
         The repository URL where the DNS records are stored. The username has to be provided as in 
         git+ssh://username@repository@branch, where the branch is optional.
-    git_ssh_key:
+    git-ssh-key:
       type: string
       description: The private key for SSH authentication.
 

--- a/charm/docs/tutorials/getting-started.md
+++ b/charm/docs/tutorials/getting-started.md
@@ -37,17 +37,17 @@ httprequest-lego-provider-0      2/2     Running   0          9m36s
 Run [`juju status`](https://juju.is/docs/olm/juju-status) to see the current status of the deployment. In the Unit list, you can see that the charm is waiting:
 
 ```bash
-httprequest-lego-provider/0*  waiting   idle   10.1.180.77         Config git_repo is required
+httprequest-lego-provider/0*  waiting   idle   10.1.180.77         Config git-repo is required
 ```
 
 This means the required configurations have not been set yet.
 
 ## Configure the Httprequest Lego Provider charm
- Provide the configurations `git_repo` and `git_ssh_key` required by the charm:
+ Provide the configurations `git-repo` and `git-ssh-key` required by the charm:
 
  ```bash
-juju config httprequest-lego-provider git_repo=git+ssh://username@host/repo@branch
-juju config httprequest-lego-provider git_ssh_key=**REDACTED**
+juju config httprequest-lego-provider git-repo=git+ssh://username@host/repo@branch
+juju config httprequest-lego-provider git-ssh-key=**REDACTED**
 ```
 You can see the message has changed:
 
@@ -73,7 +73,7 @@ httprequest-lego-provider           active       1  httprequest-lego-provider  l
 In order to access the HTTP endpoints, you'll need configure a hostname and add it to Django's allow list and configure the path routes that will be accessible:
 ```bash
 juju config nginx-ingress-integrator service-hostname=lego.local
-juju config httprequest-lego-provider django_allowed_hosts=localhost,127.0.0.1,lego.local
+juju config httprequest-lego-provider django-allowed-hosts=localhost,127.0.0.1,lego.local
 juju config nginx-ingress-integrator path-routes="/admin,/present,/cleanup"
 ```
 

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -55,9 +55,9 @@ class DjangoCharm(paas_app_charmer.django.Charm):
         """Copy files needed by git."""
         if not self._container.can_connect():
             return
-        if not self.config.get("git_repo") or not self.config.get("git_ssh_key"):
+        if not self.config.get("git-repo") or not self.config.get("git-ssh-key"):
             return
-        hostname = self.config.get("git_repo").split("@")[1].split("/")[0]
+        hostname = self.config.get("git-repo").split("@")[1].split("/")[0]
         process = self._container.exec(["ssh-keyscan", "-t", "rsa", hostname])
         output, _ = process.wait_output()
         self._container.push(
@@ -71,7 +71,7 @@ class DjangoCharm(paas_app_charmer.django.Charm):
         )
         self._container.push(
             RSA_PATH,
-            self.config.get("git_ssh_key"),
+            self.config.get("git-ssh-key"),
             encoding="utf-8",
             make_dirs=True,
             user=DJANGO_USER,
@@ -81,11 +81,11 @@ class DjangoCharm(paas_app_charmer.django.Charm):
 
     def _on_collect_app_status(self, _: ops.CollectStatusEvent) -> None:
         """Handle the status changes."""
-        if not self.config.get("git_repo"):
-            self.unit.status = ops.WaitingStatus("Config git_repo is required")
+        if not self.config.get("git-repo"):
+            self.unit.status = ops.WaitingStatus("Config git-repo is required")
             return
-        if not self.config.get("git_ssh_key"):
-            self.unit.status = ops.WaitingStatus("Config git_ssh_key is required")
+        if not self.config.get("git-ssh-key"):
+            self.unit.status = ops.WaitingStatus("Config git-ssh-key is required")
             return
 
 

--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -28,8 +28,8 @@ async def test_build_and_deploy(ops_test: OpsTest, pytestconfig: pytest.Config):
     await ops_test.model.deploy(
         os.path.abspath(charm),
         config={
-            "git_repo": "git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main",
-            "git_ssh_key": textwrap.dedent(
+            "git-repo": "git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main",
+            "git-ssh-key": textwrap.dedent(
                 """\
                 -----BEGIN OPENSSH PRIVATE KEY-----
                 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW

--- a/httprequest_lego_provider/settings.py
+++ b/httprequest_lego_provider/settings.py
@@ -4,6 +4,6 @@
 
 import os
 
-GIT_REPO_URL = os.getenv("DJANGO_GIT-REPO", default="")
-GIT_SSH_KEY = os.getenv("DJANGO_GIT-SSH-KEY", default="")
+GIT_REPO_URL = os.getenv("DJANGO_GIT_REPO", default="")
+GIT_SSH_KEY = os.getenv("DJANGO_GIT_SSH_KEY", default="")
 LOGIN_REDIRECT_URL = "/"

--- a/httprequest_lego_provider/settings.py
+++ b/httprequest_lego_provider/settings.py
@@ -4,6 +4,6 @@
 
 import os
 
-GIT_REPO_URL = os.getenv("DJANGO_GIT_REPO", default="")
-GIT_SSH_KEY = os.getenv("DJANGO_GIT_SSH_KEY", default="")
+GIT_REPO_URL = os.getenv("DJANGO_GIT-REPO", default="")
+GIT_SSH_KEY = os.getenv("DJANGO_GIT-SSH-KEY", default="")
 LOGIN_REDIRECT_URL = "/"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Rename config options to use dashes rather than underscores for consistency with framework-added options.

### Rationale

Consistency with other config options.

### Module Changes

N/A 

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
