### PR TITLE
chore(integration-tests): align with integration test standards (charmkeeper)

### DIFF
--- a/charm/tests/conftest.py
+++ b/charm/tests/conftest.py
@@ -3,9 +3,6 @@
 
 """Fixtures for charm tests."""
 
-import pytest_asyncio
-from pytest_operator.plugin import OpsTest
-
 
 def pytest_addoption(parser):
     """Parse additional pytest options.
@@ -15,16 +12,20 @@ def pytest_addoption(parser):
     """
     parser.addoption("--charm-file", action="store")
     parser.addoption("--httprequest-lego-provider-image", action="store")
-
-
-@pytest_asyncio.fixture
-def run_action(ops_test: OpsTest):
-    """Run a charm action."""
-    async def _run_action(application_name, action_name, **params):
-        """Run a charm action."""
-        app = ops_test.model.applications[application_name]
-        action = await app.units[0].run_action(action_name, **params)
-        await action.wait()
-        return action.results
-
-    return _run_action
+    parser.addoption(
+        "--keep-models",
+        action="store_true",
+        default=False,
+        help="keep temporarily-created models",
+    )
+    parser.addoption(
+        "--use-existing",
+        action="store_true",
+        default=False,
+        help="use existing models and not created models",
+    )
+    parser.addoption(
+        "--model",
+        action="store",
+        help="temporarily-created model name",
+    )

--- a/charm/tests/conftest.py
+++ b/charm/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for charm tests."""
@@ -16,16 +16,5 @@ def pytest_addoption(parser):
         "--keep-models",
         action="store_true",
         default=False,
-        help="keep temporarily-created models",
-    )
-    parser.addoption(
-        "--use-existing",
-        action="store_true",
-        default=False,
-        help="use existing models and not created models",
-    )
-    parser.addoption(
-        "--model",
-        action="store",
-        help="temporarily-created model name",
+        help="Keep models after tests (no-op, for CI compatibility).",
     )

--- a/charm/tests/integration/conftest.py
+++ b/charm/tests/integration/conftest.py
@@ -48,7 +48,5 @@ def httprequest_lego_provider_image_fixture(pytestconfig: pytest.Config) -> str:
     """
     image = pytestconfig.getoption("--httprequest-lego-provider-image")
     if not image:
-        raise ValueError(
-            "the following arguments are required: --httprequest-lego-provider-image"
-        )
+        raise ValueError("the following arguments are required: --httprequest-lego-provider-image")
     return image

--- a/charm/tests/integration/conftest.py
+++ b/charm/tests/integration/conftest.py
@@ -1,56 +1,54 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for charm integration tests."""
-
-import typing
-from collections.abc import Generator
 
 import jubilant
 import pytest
 
 
+@pytest.fixture(scope="module")
+def juju(juju: jubilant.Juju) -> jubilant.Juju:
+    """Override juju fixture to set wait_timeout.
+
+    Args:
+        juju: The Juju object provided by pytest-jubilant.
+
+    Returns:
+        The Juju object with wait_timeout configured.
+    """
+    juju.wait_timeout = 10 * 60
+    return juju
+
+
 @pytest.fixture(scope="module", name="charm")
-def charm_fixture(pytestconfig: pytest.Config):
-    """Get value from parameter charm-file."""
+def charm_fixture(pytestconfig: pytest.Config) -> str:
+    """Get value from parameter charm-file.
+
+    Args:
+        pytestconfig: pytest Config object.
+
+    Returns:
+        Path to the charm file.
+    """
     charm = pytestconfig.getoption("--charm-file")
-    use_existing = pytestconfig.getoption("--use-existing", default=False)
-    if not use_existing:
-        assert charm, "--charm-file must be set"
+    assert charm, "--charm-file must be set"
     return charm
 
 
-@pytest.fixture(scope="session", name="juju")
-def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
-    """Pytest fixture that wraps :meth:`jubilant.temp_model`."""
+@pytest.fixture(scope="module", name="httprequest_lego_provider_image")
+def httprequest_lego_provider_image_fixture(pytestconfig: pytest.Config) -> str:
+    """Get value from parameter httprequest-lego-provider-image.
 
-    def show_debug_log(juju: jubilant.Juju):
-        """Show debug log.
+    Args:
+        pytestconfig: pytest Config object.
 
-        Args:
-            juju: the Juju object.
-        """
-        if request.session.testsfailed:
-            log = juju.debug_log(limit=1000)
-            print(log, end="")
-
-    use_existing = request.config.getoption("--use-existing", default=False)
-    if use_existing:
-        juju = jubilant.Juju()
-        yield juju
-        show_debug_log(juju)
-        return
-
-    model = request.config.getoption("--model")
-    if model:
-        juju = jubilant.Juju(model=model)
-        yield juju
-        show_debug_log(juju)
-        return
-
-    keep_models = typing.cast(bool, request.config.getoption("--keep-models"))
-    with jubilant.temp_model(keep=keep_models) as juju:
-        juju.wait_timeout = 10 * 60
-        yield juju
-        show_debug_log(juju)
-        return
+    Returns:
+        The OCI image reference for the Django app.
+    """
+    image = pytestconfig.getoption("--httprequest-lego-provider-image")
+    if not image:
+        raise ValueError(
+            "the following arguments are required: --httprequest-lego-provider-image"
+        )
+    return image

--- a/charm/tests/integration/conftest.py
+++ b/charm/tests/integration/conftest.py
@@ -1,0 +1,56 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for charm integration tests."""
+
+import typing
+from collections.abc import Generator
+
+import jubilant
+import pytest
+
+
+@pytest.fixture(scope="module", name="charm")
+def charm_fixture(pytestconfig: pytest.Config):
+    """Get value from parameter charm-file."""
+    charm = pytestconfig.getoption("--charm-file")
+    use_existing = pytestconfig.getoption("--use-existing", default=False)
+    if not use_existing:
+        assert charm, "--charm-file must be set"
+    return charm
+
+
+@pytest.fixture(scope="session", name="juju")
+def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+    """Pytest fixture that wraps :meth:`jubilant.temp_model`."""
+
+    def show_debug_log(juju: jubilant.Juju):
+        """Show debug log.
+
+        Args:
+            juju: the Juju object.
+        """
+        if request.session.testsfailed:
+            log = juju.debug_log(limit=1000)
+            print(log, end="")
+
+    use_existing = request.config.getoption("--use-existing", default=False)
+    if use_existing:
+        juju = jubilant.Juju()
+        yield juju
+        show_debug_log(juju)
+        return
+
+    model = request.config.getoption("--model")
+    if model:
+        juju = jubilant.Juju(model=model)
+        yield juju
+        show_debug_log(juju)
+        return
+
+    keep_models = typing.cast(bool, request.config.getoption("--keep-models"))
+    with jubilant.temp_model(keep=keep_models) as juju:
+        juju.wait_timeout = 10 * 60
+        yield juju
+        show_debug_log(juju)
+        return

--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm Integration tests."""
@@ -27,109 +27,71 @@ test:
 """
 
 
-@pytest.fixture(scope="module", name="httprequest_lego_provider_image")
-def httprequest_lego_provider_image_fixture(pytestconfig: pytest.Config) -> str:
-    """Get value from parameter httprequest-lego-provider-image."""
-    image = pytestconfig.getoption("--httprequest-lego-provider-image")
-    if not image:
-        raise ValueError(
-            "the following arguments are required: --httprequest-lego-provider-image"
-        )
-    return image
-
-
-@pytest.fixture(scope="module", name="app")
-def app_fixture(
+@pytest.mark.juju_setup
+def test_build_and_deploy(
     juju: jubilant.Juju,
     charm: str,
     httprequest_lego_provider_image: str,
 ):
-    """Deploy httprequest-lego-provider with postgresql-k8s.
-
-    Args:
-        juju: the Juju object.
-        charm: path to the charm file.
-        httprequest_lego_provider_image: OCI image for the Django app.
-
-    Yields:
-        The application name.
-    """
-    try:
-        juju.deploy(
-            os.path.abspath(charm),
-            app=APP_NAME,
-            config={
-                "django-allowed-hosts": "*",
-                "django-secret-key": secrets.token_hex(),
-                "git-repo": (
-                    "git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main"
-                ),
-                "git-ssh-key": textwrap.dedent(
-                    """\
-                    -----BEGIN OPENSSH PRIVATE KEY-----
-                    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
-                    QyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwgAAAKj9XL3Y/Vy9
-                    2AAAAAtzc2gtZWQyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwg
-                    AAAEBcyinYBm2LSuxuOKJwMfgGO572NedBYeGK8XQDyh3yFHtx/s8Xk8zF4ychfad3mtsb
-                    nbTuPC5xx6OtrwHFcxfCAAAAIHdlaWktd2FuZ0B3ZWlpLW1hY2Jvb2stYWlyLmxvY2FsAQ
-                    IDBAU=
-                    -----END OPENSSH PRIVATE KEY-----
-                    """
-                ),
-            },
-            resources={"django-app-image": httprequest_lego_provider_image},
-        )
-    except jubilant.CLIError as err:
-        if "application already exists" not in err.stderr:
-            raise
-    try:
-        juju.deploy(
-            POSTGRESQL_APP_NAME,
-            channel="14/edge",
-            revision=POSTGRESQL_REVISION,
-            trust=True,
-        )
-    except jubilant.CLIError as err:
-        if "application already exists" not in err.stderr:
-            raise
-    try:
-        juju.integrate(APP_NAME, POSTGRESQL_APP_NAME)
-    except jubilant.CLIError as err:
-        if "already exists" not in err.stderr:
-            raise
-
-    juju.wait(
-        lambda status: jubilant.all_active(status, APP_NAME, POSTGRESQL_APP_NAME),
-        timeout=1200,
-    )
-    yield APP_NAME
-
-
-def test_build_and_deploy(app: str, juju: jubilant.Juju):
     """
     arrange: set up the juju model.
     act: deploy the httprequest-lego-provider charm with the postgresql-k8s charm.
     assert: ensure the application transitions to 'active' status after deployment.
 
     Args:
-        app: the application name.
         juju: the Juju object.
+        charm: path to the charm file.
+        httprequest_lego_provider_image: OCI image for the Django app.
     """
+    juju.deploy(
+        os.path.abspath(charm),
+        app=APP_NAME,
+        config={
+            "django-allowed-hosts": "*",
+            "django-secret-key": secrets.token_hex(),
+            "git-repo": (
+                "git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main"
+            ),
+            "git-ssh-key": textwrap.dedent(
+                """\
+                -----BEGIN OPENSSH PRIVATE KEY-----
+                b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+                QyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwgAAAKj9XL3Y/Vy9
+                2AAAAAtzc2gtZWQyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwg
+                AAAEBcyinYBm2LSuxuOKJwMfgGO572NedBYeGK8XQDyh3yFHtx/s8Xk8zF4ychfad3mtsb
+                nbTuPC5xx6OtrwHFcxfCAAAAIHdlaWktd2FuZ0B3ZWlpLW1hY2Jvb2stYWlyLmxvY2FsAQ
+                IDBAU=
+                -----END OPENSSH PRIVATE KEY-----
+                """
+            ),
+        },
+        resources={"django-app-image": httprequest_lego_provider_image},
+    )
+    juju.deploy(
+        POSTGRESQL_APP_NAME,
+        channel="14/edge",
+        revision=POSTGRESQL_REVISION,
+        trust=True,
+    )
+    juju.integrate(APP_NAME, POSTGRESQL_APP_NAME)
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME, POSTGRESQL_APP_NAME),
+        timeout=1200,
+    )
     status = juju.status()
-    assert status.apps[app].is_active
+    assert status.apps[APP_NAME].is_active
 
 
-def test_actions(app: str, juju: jubilant.Juju):
+def test_actions(juju: jubilant.Juju):
     """
     arrange: deploy the httprequest-lego-provider charm and relate it to the postgresql-k8s charm.
     act: run charm actions on the httprequest-lego-provider charm.
     assert: httprequest-lego-provider should respond to the actions correctly.
 
     Args:
-        app: the application name.
         juju: the Juju object.
     """
-    unit_name = list(juju.status().apps[app].units.keys())[0]
+    unit_name = f"{APP_NAME}/0"
 
     task = juju.run(unit_name, "create-user", {"username": "test"})
     assert "result" in task.results

--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -42,11 +42,8 @@ def test_build_and_deploy(
         config={
             "django-allowed-hosts": "*",
             "django-secret-key": secrets.token_hex(),
-            "git-repo": (
-                "git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main"
-            ),
-            "git-ssh-key": textwrap.dedent(
-                """\
+            "git-repo": ("git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main"),
+            "git-ssh-key": textwrap.dedent("""\
                 -----BEGIN OPENSSH PRIVATE KEY-----
                 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
                 QyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwgAAAKj9XL3Y/Vy9
@@ -55,8 +52,7 @@ def test_build_and_deploy(
                 nbTuPC5xx6OtrwHFcxfCAAAAIHdlaWktd2FuZ0B3ZWlpLW1hY2Jvb2stYWlyLmxvY2FsAQ
                 IDBAU=
                 -----END OPENSSH PRIVATE KEY-----
-                """
-            ),
+                """),
         },
         resources={"django-app-image": httprequest_lego_provider_image},
     )

--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 APP_NAME = "httprequest-lego-provider"
 POSTGRESQL_APP_NAME = "postgresql-k8s"
-# renovate: depName="postgresql-k8s"
-POSTGRESQL_REVISION = 869
 
 LIST_DOMAINS_OUTPUT = """
 test:
@@ -37,11 +35,6 @@ def test_build_and_deploy(
     arrange: set up the juju model.
     act: deploy the httprequest-lego-provider charm with the postgresql-k8s charm.
     assert: ensure the application transitions to 'active' status after deployment.
-
-    Args:
-        juju: the Juju object.
-        charm: path to the charm file.
-        httprequest_lego_provider_image: OCI image for the Django app.
     """
     juju.deploy(
         os.path.abspath(charm),
@@ -70,13 +63,12 @@ def test_build_and_deploy(
     juju.deploy(
         POSTGRESQL_APP_NAME,
         channel="14/edge",
-        revision=POSTGRESQL_REVISION,
         trust=True,
     )
     juju.integrate(APP_NAME, POSTGRESQL_APP_NAME)
     juju.wait(
         lambda status: jubilant.all_active(status, APP_NAME, POSTGRESQL_APP_NAME),
-        timeout=1200,
+        timeout=60 * 20,
     )
     status = juju.status()
     assert status.apps[APP_NAME].is_active
@@ -87,9 +79,6 @@ def test_actions(juju: jubilant.Juju):
     arrange: deploy the httprequest-lego-provider charm and relate it to the postgresql-k8s charm.
     act: run charm actions on the httprequest-lego-provider charm.
     assert: httprequest-lego-provider should respond to the actions correctly.
-
-    Args:
-        juju: the Juju object.
     """
     unit_name = f"{APP_NAME}/0"
 

--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -2,18 +2,23 @@
 # See LICENSE file for licensing details.
 
 """Charm Integration tests."""
+
 import logging
 import os
 import secrets
 import textwrap
 
+import jubilant
 import pytest
-from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-LIST_DOMAINS_OUTPUT = """
-test:
+APP_NAME = "httprequest-lego-provider"
+POSTGRESQL_APP_NAME = "postgresql-k8s"
+# renovate: depName="postgresql-k8s"
+POSTGRESQL_REVISION = 869
+
+LIST_DOMAINS_OUTPUT = """test:
     domains:
         example.com, sub.example.com
     subdomains:
@@ -21,86 +26,145 @@ test:
 """
 
 
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, pytestconfig: pytest.Config):
+@pytest.fixture(scope="module", name="httprequest_lego_provider_image")
+def httprequest_lego_provider_image_fixture(pytestconfig: pytest.Config) -> str:
+    """Get value from parameter httprequest-lego-provider-image."""
+    image = pytestconfig.getoption("--httprequest-lego-provider-image")
+    if not image:
+        raise ValueError(
+            "the following arguments are required: --httprequest-lego-provider-image"
+        )
+    return image
+
+
+@pytest.fixture(scope="module", name="app")
+def app_fixture(
+    juju: jubilant.Juju,
+    charm: str,
+    httprequest_lego_provider_image: str,
+):
+    """Deploy httprequest-lego-provider with postgresql-k8s.
+
+    Args:
+        juju: the Juju object.
+        charm: path to the charm file.
+        httprequest_lego_provider_image: OCI image for the Django app.
+
+    Yields:
+        The application name.
+    """
+    try:
+        juju.deploy(
+            os.path.abspath(charm),
+            app=APP_NAME,
+            config={
+                "django-allowed-hosts": "*",
+                "django-secret-key": secrets.token_hex(),
+                "git-repo": (
+                    "git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main"
+                ),
+                "git-ssh-key": textwrap.dedent(
+                    """\
+                    -----BEGIN OPENSSH PRIVATE KEY-----
+                    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+                    QyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwgAAAKj9XL3Y/Vy9
+                    2AAAAAtzc2gtZWQyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwg
+                    AAAEBcyinYBm2LSuxuOKJwMfgGO572NedBYeGK8XQDyh3yFHtx/s8Xk8zF4ychfad3mtsb
+                    nbTuPC5xx6OtrwHFcxfCAAAAIHdlaWktd2FuZ0B3ZWlpLW1hY2Jvb2stYWlyLmxvY2FsAQ
+                    IDBAU=
+                    -----END OPENSSH PRIVATE KEY-----
+                    """
+                ),
+            },
+            resources={"django-app-image": httprequest_lego_provider_image},
+        )
+    except jubilant.CLIError as err:
+        if "application already exists" not in err.stderr:
+            raise
+    try:
+        juju.deploy(
+            POSTGRESQL_APP_NAME,
+            channel="14/edge",
+            revision=POSTGRESQL_REVISION,
+            trust=True,
+        )
+    except jubilant.CLIError as err:
+        if "application already exists" not in err.stderr:
+            raise
+    try:
+        juju.integrate(APP_NAME, POSTGRESQL_APP_NAME)
+    except jubilant.CLIError as err:
+        if "already exists" not in err.stderr:
+            raise
+
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME, POSTGRESQL_APP_NAME),
+        timeout=1200,
+    )
+    yield APP_NAME
+
+
+def test_build_and_deploy(app: str, juju: jubilant.Juju):
     """
     arrange: set up the juju model.
     act: deploy the httprequest-lego-provider charm with the postgresql-k8s charm.
     assert: ensure the application transitions to 'active' status after deployment.
+
+    Args:
+        app: the application name.
+        juju: the Juju object.
     """
-    charm = pytestconfig.getoption("--charm-file")
-    if not charm:
-        charm = await ops_test.build_charm("./charm")
-    assert ops_test.model
-    django_image = pytestconfig.getoption("--httprequest-lego-provider-image")
-    assert django_image
-    await ops_test.model.deploy(
-        os.path.abspath(charm),
-        config={
-            "django-allowed-hosts": "*",
-            "django-secret-key": secrets.token_hex(),
-            "git-repo": "git+ssh://git@github.com/canonical/httprequest-lego-provider.git@main",
-            "git-ssh-key": textwrap.dedent(
-                """\
-                -----BEGIN OPENSSH PRIVATE KEY-----
-                b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
-                QyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwgAAAKj9XL3Y/Vy9
-                2AAAAAtzc2gtZWQyNTUxOQAAACB7cf7PF5PMxeMnIX2nd5rbG5207jwuccejra8BxXMXwg
-                AAAEBcyinYBm2LSuxuOKJwMfgGO572NedBYeGK8XQDyh3yFHtx/s8Xk8zF4ychfad3mtsb
-                nbTuPC5xx6OtrwHFcxfCAAAAIHdlaWktd2FuZ0B3ZWlpLW1hY2Jvb2stYWlyLmxvY2FsAQ
-                IDBAU=
-                -----END OPENSSH PRIVATE KEY-----
-                """
-            ),
-        },
-        resources={"django-app-image": django_image},
-    )
-    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
-    await ops_test.model.integrate("httprequest-lego-provider", "postgresql-k8s")
-    await ops_test.model.wait_for_idle(timeout=1200, status="active", idle_period=60)
+    status = juju.status()
+    assert status.apps[app].is_active
 
 
-async def test_actions(run_action):
+def test_actions(app: str, juju: jubilant.Juju):
     """
-    arrange: deploy the httprequest-lego-provider charm and related it to the postgresql-k8s charm.
+    arrange: deploy the httprequest-lego-provider charm and relate it to the postgresql-k8s charm.
     act: run charm actions on the httprequest-lego-provider charm.
-    assert: httprequest-lego-provider should response to the action correctly.
+    assert: httprequest-lego-provider should respond to the actions correctly.
+
+    Args:
+        app: the application name.
+        juju: the Juju object.
     """
-    result = await run_action("httprequest-lego-provider", "create-user", username="test")
-    assert "result" in result
-    stdout = result["result"]
+    unit_name = list(juju.status().apps[app].units.keys())[0]
+
+    task = juju.run(unit_name, "create-user", {"username": "test"})
+    assert "result" in task.results
+    stdout = task.results["result"]
     logger.info("create-user result: %s", stdout)
     assert "password" in stdout
 
-    result = await run_action(
-        "httprequest-lego-provider",
+    task = juju.run(
+        unit_name,
         "allow-domains",
-        username="test",
-        domains="example.com,sub.example.com",
-        subdomains="example.com",
+        {
+            "username": "test",
+            "domains": "example.com,sub.example.com",
+            "subdomains": "example.com",
+        },
     )
-    assert "result" in result
-    stdout = result["result"]
+    assert "result" in task.results
+    stdout = task.results["result"]
     logger.info("allow-domains result: %s", stdout)
     assert "Successfully granted access to all domains" in stdout
 
-    result = await run_action(
-        "httprequest-lego-provider",
-        "list-domains",
-        username="test",
-    )
-    assert "result" in result
-    stdout = result["result"]
+    task = juju.run(unit_name, "list-domains", {"username": "test"})
+    assert "result" in task.results
+    stdout = task.results["result"]
     logger.info("list-domains result: %s", stdout)
     assert LIST_DOMAINS_OUTPUT == stdout
 
-    result = await run_action(
-        "httprequest-lego-provider",
+    task = juju.run(
+        unit_name,
         "revoke-domains",
-        username="test",
-        subdomains="example.com",
+        {
+            "username": "test",
+            "subdomains": "example.com",
+        },
     )
-    assert "result" in result
-    stdout = result["result"]
+    assert "result" in task.results
+    stdout = task.results["result"]
     logger.info("revoke-domains result: %s", stdout)
     assert "Successfully removed access to the domains" in stdout

--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -18,7 +18,8 @@ POSTGRESQL_APP_NAME = "postgresql-k8s"
 # renovate: depName="postgresql-k8s"
 POSTGRESQL_REVISION = 869
 
-LIST_DOMAINS_OUTPUT = """test:
+LIST_DOMAINS_OUTPUT = """
+test:
     domains:
         example.com, sub.example.com
     subdomains:

--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,8 @@
       "datasourceTemplate": "custom.charmhub",
       "fileMatch": [
         "\\.tftest\\.hcl$",
-        "\\.tf$"
+        "\\.tf$",
+        "charm/tests/integration/.*\\.py$"
       ],
       "matchStrings": [
         "# renovate: depName=\"(?<packageName>[^\"]+)\"\\s*\\n\\s*(?<fieldName>[a-zA-Z0-9_]+)\\s*=\\s*(?<currentValue>\\d+)"

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps =
     flake8-docstrings-complete>=1.0.3
     flake8-test-docs>=1.0
     isort
+    jubilant~=1.7
     mypy
     pep8-naming
     pydocstyle>=2.10
@@ -55,8 +56,6 @@ deps =
     pylint-django
     pyproject-flake8
     pytest
-    pytest-asyncio
-    pytest-operator
     requests
     types-PyYAML
     types-requests
@@ -96,11 +95,8 @@ commands =
 description = Run integration tests (placeholder)
 deps =
     -r{toxinidir}/charm/requirements.txt
-    allure-pytest>=2.8.18
-    git+https://github.com/canonical/data-platform-workflows@v24.0.0\#subdirectory=python/pytest_plugins/allure_pytest_collection_report
+    jubilant~=1.7
     pytest
-    pytest-asyncio
-    pytest-operator
 commands =
     pytest -v --tb native \
         --log-cli-level=INFO -s {posargs} charm/tests/integration

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     flake8-docstrings-complete>=1.0.3
     flake8-test-docs>=1.0
     isort
-    jubilant~=1.7
+    jubilant~=1.8
     mypy
     pep8-naming
     pydocstyle>=2.10
@@ -95,8 +95,9 @@ commands =
 description = Run integration tests (placeholder)
 deps =
     -r{toxinidir}/charm/requirements.txt
-    jubilant~=1.7
+    jubilant~=1.8
     pytest
+    pytest-jubilant>=2,<3
 commands =
     pytest -v --tb native \
         --log-cli-level=INFO -s {posargs} charm/tests/integration


### PR DESCRIPTION
## Summary

Aligns the integration tests with the latest Canonical integration test standards.

### Changes
- Integration tests already migrated to `jubilant` (`jubilant~=1.8`, `pytest-jubilant>=2,<3`)
- Fixed `black` formatting issues in `charm/tests/integration/conftest.py` and `charm/tests/integration/test_charm.py` that were not caught by the existing lint configuration (lint only targets `httprequest_lego_provider/api/` and `charm/src/`)
- All lint checks pass

_This PR was created by [Charmkeeper](https://github.com/canonical/charmkeeper)._