### PR TITLE
Add landing page for how-to

### DIFF
--- a/charm/docs/how-to/index.md
+++ b/charm/docs/how-to/index.md
@@ -24,7 +24,7 @@ basic operations you can complete with the charm.
 Maintenance
 -----------
 
-These guides provide instructions on maintenance-related operations such as upgrade and back up.
+These guides provide instructions on maintenance-related operations such as upgrades and backups.
 
 - [Upgrade](https://charmhub.io/httprequest-lego-provider/docs/upgrade)
 - [Back up and restore](https://charmhub.io/httprequest-lego-provider/docs/back-up-restore)

--- a/charm/docs/how-to/index.md
+++ b/charm/docs/how-to/index.md
@@ -1,0 +1,24 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "How-to guides for operating the HTTPRequest Lego provider charm, including basic operations, upgrades, and development. "
+---
+
+How-to guides
+=============
+
+The following guides cover key processes and common tasks for managing and
+using the `httprequest-lego-provider` charm.
+
+Basic operations
+----------------
+
+Once you've finished setting up the charm, now you can perform a number
+of actions with your deployment. These guides provide instructions on
+basic operations you can complete with the charm.
+
+- [How to manage users](https://charmhub.io/httprequest-lego-provider/docs/manage-users)
+- [How to manage domains](https://charmhub.io/httprequest-lego-provider/docs/manage-domains)
+- [Back up and restore](https://charmhub.io/httprequest-lego-provider/docs/back-up-restore)
+- [Upgrade](https://charmhub.io/httprequest-lego-provider/docs/upgrade)
+- [How to troubleshoot API timeouts](https://charmhub.io/httprequest-lego-provider/docs/troubleshoot-api-timeouts)

--- a/charm/docs/how-to/index.md
+++ b/charm/docs/how-to/index.md
@@ -19,6 +19,12 @@ basic operations you can complete with the charm.
 
 - [How to manage users](https://charmhub.io/httprequest-lego-provider/docs/manage-users)
 - [How to manage domains](https://charmhub.io/httprequest-lego-provider/docs/manage-domains)
-- [Back up and restore](https://charmhub.io/httprequest-lego-provider/docs/back-up-restore)
-- [Upgrade](https://charmhub.io/httprequest-lego-provider/docs/upgrade)
 - [How to troubleshoot API timeouts](https://charmhub.io/httprequest-lego-provider/docs/troubleshoot-api-timeouts)
+
+Maintenance
+-----------
+
+These guides provide instructions on maintenance-related operations such as upgrade and back up.
+
+- [Upgrade](https://charmhub.io/httprequest-lego-provider/docs/upgrade)
+- [Back up and restore](https://charmhub.io/httprequest-lego-provider/docs/back-up-restore)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Added landing page for how-to.

Was going to add a `Troubleshooting` section. However, there is only one entry. I think we should avoid sections with only one entry 

### Rationale

<!-- The reason the change is needed -->

Part of the landing page initiative. 

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
