### PR TITLE
chore: migrate from self-hosted edge runner to GitHub-hosted runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,8 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false
+      runs-on-base: ubuntu-24.04
       vale-style-check: true
   integration-tests:
     uses: 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ jobs:
     with:
       self-hosted-runner: false
       runs-on-base: ubuntu-24.04
+      python-version: "3.12"
       vale-style-check: true
   integration-tests:
     uses: 


### PR DESCRIPTION
## Summary

This PR migrates unit and integration test workflows from the self-hosted `amd64-noble-medium-edge-ps7` ("edge") runner to GitHub-hosted `ubuntu-24.04` runners, which are free and unlimited for public repositories.

The `self-hosted-runner` and `self-hosted-runner-label` inputs are removed from the reusable workflow calls; the operator-workflows default then falls back to GitHub-hosted runners.