### PR TITLE
Use shallow clone and refactor DNS record helpers

### DIFF
--- a/httprequest_lego_provider/api/dns.py
+++ b/httprequest_lego_provider/api/dns.py
@@ -5,6 +5,7 @@
 import io
 import logging
 from collections.abc import Iterable
+from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Tuple
@@ -89,12 +90,43 @@ def _remove_subdomain_entries_from_file_content(
     return new_content
 
 
-def write_dns_record(fqdn: str, value: str) -> None:  # pylint: disable=too-many-locals
-    """Write a DNS record.
+def _write_record_file(repo_dir: str | PathLike[str] | None, fqdn: str, value: str | None) -> str:
+    """Update the DNS record file in the working tree for the given FQDN.
 
     Args:
-        fqdn: the FQDN for which to add a record.
-        value: ACME challenge for DNS record to add.
+        repo_dir: the repository working tree directory.
+        fqdn: the FQDN for which to update the record.
+        value: ACME challenge for the DNS record to add, or None to only remove it.
+
+    Returns:
+        the relative filename of the updated DNS record file.
+
+    Raises:
+        DnsSourceUpdateError: if the DNS record file does not exist.
+    """
+    domain, subdomain = _get_domain_and_subdomain_from_fqdn(fqdn)
+    filename = FILENAME_TEMPLATE.format(domain=domain)
+    dns_record_file = Path(f"{repo_dir}/{filename}")
+    try:
+        content = dns_record_file.read_text("utf-8")
+    except FileNotFoundError as exc:
+        raise DnsSourceUpdateError(
+            f"{filename} file not found in git repository. Is this site configured for DNS?"
+        ) from exc
+    new_content = _remove_subdomain_entries_from_file_content(io.StringIO(content), subdomain)
+    if value is not None:
+        new_content.append(RECORD_CONTENT.format(record=subdomain, value=value))
+    dns_record_file.write_text("".join(new_content), encoding="utf-8")
+    return filename
+
+
+def _update_dns_record(fqdn: str, value: str | None, commit_action: str) -> None:
+    """Update the git repository for a DNS record, removing any existing entry.
+
+    Args:
+        fqdn: the FQDN for which to update the record.
+        value: ACME challenge for the DNS record to add, or None to only remove it.
+        commit_action: the verb used in the commit message (e.g. "Add" or "Remove").
 
     Raises:
         DnsSourceUpdateError: if an error while updating the repository occurs.
@@ -102,28 +134,26 @@ def write_dns_record(fqdn: str, value: str) -> None:  # pylint: disable=too-many
     user, base_url, branch = parse_repository_url(GIT_REPO_URL)
     with TemporaryDirectory() as tmp_dir:
         try:
-            repo = Repo.clone_from(base_url, tmp_dir, branch=branch)
+            repo = Repo.clone_from(base_url, tmp_dir, branch=branch, depth=1)
             config_writer = repo.config_writer()
             config_writer.set_value("user", "name", user)
             config_writer.release()
-            domain, subdomain = _get_domain_and_subdomain_from_fqdn(fqdn)
-            filename = FILENAME_TEMPLATE.format(domain=domain)
-            dns_record_file = Path(f"{repo.working_tree_dir}/{filename}")
-            content = dns_record_file.read_text("utf-8")
-            new_content = _remove_subdomain_entries_from_file_content(
-                io.StringIO(content), subdomain
-            )
-            new_content.append(RECORD_CONTENT.format(record=subdomain, value=value))
-            dns_record_file.write_text("".join(new_content), encoding="utf-8")
+            filename = _write_record_file(repo.working_tree_dir, fqdn, value)
             repo.index.add([filename])
-            repo.git.commit("-m", f"Add {fqdn} record")
+            repo.git.commit("-m", f"{commit_action} {fqdn} record")
             repo.remote(name="origin").push()
-        except FileNotFoundError as exc:
-            raise DnsSourceUpdateError(
-                f"{filename} file not found in git repository. Is this site configured for DNS?"
-            ) from exc
         except (GitCommandError, ValueError) as ex:
             raise DnsSourceUpdateError(str(ex)) from ex
+
+
+def write_dns_record(fqdn: str, value: str) -> None:
+    """Write a DNS record.
+
+    Args:
+        fqdn: the FQDN for which to add a record.
+        value: ACME challenge for DNS record to add.
+    """
+    _update_dns_record(fqdn, value, "Add")
 
 
 def remove_dns_record(fqdn: str) -> None:
@@ -131,31 +161,5 @@ def remove_dns_record(fqdn: str) -> None:
 
     Args:
         fqdn: the FQDN for which to delete the record.
-
-    Raises:
-        DnsSourceUpdateError: if an error while updating the repository occurs.
     """
-    user, base_url, branch = parse_repository_url(GIT_REPO_URL)
-    with TemporaryDirectory() as tmp_dir:
-        try:
-            repo = Repo.clone_from(base_url, tmp_dir, branch=branch)
-            config_writer = repo.config_writer()
-            config_writer.set_value("user", "name", user)
-            config_writer.release()
-            domain, subdomain = _get_domain_and_subdomain_from_fqdn(fqdn)
-            filename = FILENAME_TEMPLATE.format(domain=domain)
-            dns_record_file = Path(f"{repo.working_tree_dir}/{filename}")
-            content = dns_record_file.read_text("utf-8")
-            new_content = _remove_subdomain_entries_from_file_content(
-                io.StringIO(content), subdomain
-            )
-            dns_record_file.write_text("".join(new_content), encoding="utf-8")
-            repo.index.add([filename])
-            repo.git.commit("-m", f"Remove {fqdn} record")
-            repo.remote(name="origin").push()
-        except FileNotFoundError as exc:
-            raise DnsSourceUpdateError(
-                f"{filename} file not found in git repository. Is this site configured for DNS?"
-            ) from exc
-        except (GitCommandError, ValueError) as ex:
-            raise DnsSourceUpdateError(str(ex)) from ex
+    _update_dns_record(fqdn, None, "Remove")

--- a/httprequest_lego_provider/api/tests/test_dns.py
+++ b/httprequest_lego_provider/api/tests/test_dns.py
@@ -140,6 +140,30 @@ def test_remove_dns_record(
     repo_mock.remote(name="origin").push.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "action",
+    [write_dns_record, remove_dns_record],
+)
+@patch.object(Path, "read_text", side_effect=FileNotFoundError)
+@patch.object(Repo, "clone_from")
+@patch("api.dns.GIT_REPO_URL", "git+ssh://user@git.server/repo_name")
+def test_dns_record_missing_domain_file_raises(repo_patch: Mock, _, action):
+    """
+    arrange: mock the repo and make reading the domain file raise FileNotFoundError.
+    act: attempt to write or remove a DNS record for an unconfigured site.
+    assert: a DnsSourceUpdateError exception is raised.
+    """
+    repo_patch.return_value = MagicMock(spec=Repo)
+
+    fqdn = "site.example.com"
+
+    with pytest.raises(DnsSourceUpdateError, match="configured for DNS"):
+        if action is write_dns_record:
+            action(fqdn, secrets.token_hex())
+        else:
+            action(fqdn)
+
+
 def test_parse_repository_url():
     """
     arrange: do nothing.

--- a/httprequest_lego_provider/api/tests/test_dns.py
+++ b/httprequest_lego_provider/api/tests/test_dns.py
@@ -64,7 +64,9 @@ def test_write_dns_record(
     )
     write_dns_record(fqdn, token)
 
-    repo_patch.assert_called_once_with("git+ssh://user@git.server/repo_name", ANY, branch="lego")
+    repo_patch.assert_called_once_with(
+        "git+ssh://user@git.server/repo_name", ANY, branch="lego", depth=1
+    )
     repo_mock.config_writer().set_value.assert_called_once_with("user", "name", "user")
     write_patch.assert_called_once_with(
         (
@@ -125,7 +127,9 @@ def test_remove_dns_record(
 
     remove_dns_record(fqdn)
 
-    repo_patch.assert_called_once_with("git+ssh://user@git.server/repo_name", ANY, branch=None)
+    repo_patch.assert_called_once_with(
+        "git+ssh://user@git.server/repo_name", ANY, branch=None, depth=1
+    )
     repo_mock.config_writer().set_value.assert_called_once_with("user", "name", "user")
     write_patch.assert_called_once_with(
         "site1 600 IN TXT \042sometoken\042\nsite3 600 IN TXT \042sometoken\042\n",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
 
- Clone with depth=1 to fetch only the latest commit
- Extract shared _update_dns_record and _write_record_file helpers

### Rationale

<!-- The reason the change is needed -->

Should speed up the git clone significantly. Since updating DNS record does not need to look at history this should not result in a functional difference.

The refactor change is just for cleaner code.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
